### PR TITLE
Add parameters for distributed search and selecting Solr shards.

### DIFF
--- a/esgf_wget/views.py
+++ b/esgf_wget/views.py
@@ -24,6 +24,7 @@ def generate_wget_script(request):
     query_url = ESGF_SOLR_URL + '/files/select'
     file_limit = WGET_SCRIPT_FILE_DEFAULT_LIMIT
     use_distrib = True
+    requested_shards = []
 
     # Gather dataset_ids
     if request.method == 'POST':
@@ -34,6 +35,8 @@ def generate_wget_script(request):
                 use_distrib = True
             else:
                 return HttpResponse('Parameter \"distrib\" must be set to true or false.')
+        if request.POST.get('shards'):
+            requested_shards = request.POST.getlist('shards')
         if request.POST.get('limit'):
             file_limit = min(int(request.POST['limit']), WGET_SCRIPT_FILE_MAX_LIMIT)
         if request.POST.get('dataset_id'):
@@ -48,6 +51,8 @@ def generate_wget_script(request):
                 use_distrib = True
             else:
                 return HttpResponse('Parameter \"distrib\" must be set to true or false.')
+        if request.GET.get('shards'):
+            requested_shards = request.GET.getlist('shards')
         if request.GET.get('limit'):
             file_limit = min(int(request.GET['limit']), WGET_SCRIPT_FILE_MAX_LIMIT)
         if request.GET.get('dataset_id'):
@@ -75,7 +80,10 @@ def generate_wget_script(request):
 
     # Use shards for distributed search if 'distrib' is true, otherwise use only local search
     if use_distrib:
-        if len(ESGF_SOLR_SHARDS) > 0:
+        if len(requested_shards) > 0:
+            shards = ','.join([s + '/files' for s in requested_shards])
+            query_params.update(dict(shards=shards))
+        elif len(ESGF_SOLR_SHARDS) > 0:
             shards = ','.join([s + '/files' for s in ESGF_SOLR_SHARDS])
             query_params.update(dict(shards=shards))
 

--- a/esgf_wget/views.py
+++ b/esgf_wget/views.py
@@ -28,8 +28,12 @@ def generate_wget_script(request):
     # Gather dataset_ids
     if request.method == 'POST':
         if request.POST.get('distrib'):
-            if request.POST['distrib'] == 'false':
+            if request.POST['distrib'].lower() == 'false':
                 use_distrib = False
+            elif request.POST['distrib'].lower() == 'true':
+                use_distrib = True
+            else:
+                return HttpResponse('Parameter \"distrib\" must be set to true or false.')
         if request.POST.get('limit'):
             file_limit = min(int(request.POST['limit']), WGET_SCRIPT_FILE_MAX_LIMIT)
         if request.POST.get('dataset_id'):
@@ -38,8 +42,12 @@ def generate_wget_script(request):
             return HttpResponse('No datasets selected.')
     elif request.method == 'GET':
         if request.GET.get('distrib'):
-            if request.GET['distrib'] == 'false':
+            if request.GET['distrib'].lower() == 'false':
                 use_distrib = False
+            elif request.GET['distrib'].lower() == 'true':
+                use_distrib = True
+            else:
+                return HttpResponse('Parameter \"distrib\" must be set to true or false.')
         if request.GET.get('limit'):
             file_limit = min(int(request.GET['limit']), WGET_SCRIPT_FILE_MAX_LIMIT)
         if request.GET.get('dataset_id'):

--- a/esgf_wget/views.py
+++ b/esgf_wget/views.py
@@ -21,7 +21,7 @@ def home(request):
 @csrf_exempt
 def generate_wget_script(request):
 
-    query_url = ESGF_SOLR_URL + '/select'
+    query_url = ESGF_SOLR_URL + '/files/select'
     file_limit = WGET_SCRIPT_FILE_DEFAULT_LIMIT
     use_distrib = True
 
@@ -76,7 +76,7 @@ def generate_wget_script(request):
     # Use shards for distributed search if 'distrib' is true, otherwise use only local search
     if use_distrib:
         if len(ESGF_SOLR_SHARDS) > 0:
-            shards = ','.join(ESGF_SOLR_SHARDS)
+            shards = ','.join([s + '/files' for s in ESGF_SOLR_SHARDS])
             query_params.update(dict(shards=shards))
 
     # Fetch the number of files for the query


### PR DESCRIPTION
The parameter `distrib` is used by esg-search to select whether or not to use distributed search, where all Solr shards of the search node are used for a query.  If `distrib=false`, then only a local search of the node will be used.

The `shards` parameter is used to select which Solr shards to use for a query rather than the default shards used by the API.

This PR will also fix a bug where the `limit` parameter for a GET request is being accessed from the POST parameters.