### PR TITLE
Add the parameter 'simple' for creating simplified wget scripts

### DIFF
--- a/esgf_wget/templates/wget-simple-template.sh
+++ b/esgf_wget/templates/wget-simple-template.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+download_files=(
+{% spaceless %}{% for file in files %}'{{file.url}}'
+{% endfor %}{% endspaceless %}
+)
+
+for i in "${download_files[@]}"
+do
+   wget $i
+done

--- a/esgf_wget/views.py
+++ b/esgf_wget/views.py
@@ -25,6 +25,7 @@ def generate_wget_script(request):
     file_limit = WGET_SCRIPT_FILE_DEFAULT_LIMIT
     use_distrib = True
     requested_shards = []
+    script_template_file = 'wget-template.sh'
 
     # Gather dataset_ids and other parameters
     if request.method == 'POST':
@@ -33,6 +34,15 @@ def generate_wget_script(request):
         url_params = request.GET
     else:
         return HttpResponse('Request method must be POST or GET.')
+
+    # Create a simplified script that only runs wget on a list of files
+    if url_params.get('simple'):
+        if url_params['simple'].lower() == 'false':
+            script_template_file = 'wget-template.sh'
+        elif url_params['simple'].lower() == 'true':
+            script_template_file = 'wget-simple-template.sh'
+        else:
+            return HttpResponse('Parameter \"simple\" must be set to true or false.')
 
     if url_params.get('distrib'):
         if url_params['distrib'].lower() == 'false':
@@ -125,7 +135,7 @@ def generate_wget_script(request):
                    file_limit=file_limit,
                    files=file_list,
                    warning_message=wget_warn)
-    wget_script = render(request, 'wget-template.sh', context)
+    wget_script = render(request, script_template_file, context)
 
     script_filename = current_datetime.strftime('wget-%Y%m%d%H%M%S.sh')
 


### PR DESCRIPTION
Resolves #15 
By setting the parameter `simple=true`, you can create wget scripts that are only a list of file URLs and a loop for downloading them.

Example:
```
#!/bin/bash

download_files=(
'http://aims3.llnl.gov/thredds/fileServer/user_pub_work/CMIP6/CMIP/E3SM-Project/E3SM-1-1/piControl/r1i1p1f1/Amon/huss/gr/v20191029/huss_Amon_E3SM-1-1_piControl_r1i1p1f1_gr_185001-187412.nc'
'http://aims3.llnl.gov/thredds/fileServer/user_pub_work/CMIP6/CMIP/E3SM-Project/E3SM-1-1/piControl/r1i1p1f1/Amon/huss/gr/v20191029/huss_Amon_E3SM-1-1_piControl_r1i1p1f1_gr_187501-189912.nc'
'http://aims3.llnl.gov/thredds/fileServer/user_pub_work/CMIP6/CMIP/E3SM-Project/E3SM-1-1/piControl/r1i1p1f1/Amon/huss/gr/v20191029/huss_Amon_E3SM-1-1_piControl_r1i1p1f1_gr_190001-192412.nc'
'http://aims3.llnl.gov/thredds/fileServer/user_pub_work/CMIP6/CMIP/E3SM-Project/E3SM-1-1/piControl/r1i1p1f1/Amon/huss/gr/v20191029/huss_Amon_E3SM-1-1_piControl_r1i1p1f1_gr_192501-194912.nc'
'http://aims3.llnl.gov/thredds/fileServer/user_pub_work/CMIP6/CMIP/E3SM-Project/E3SM-1-1/piControl/r1i1p1f1/Amon/huss/gr/v20191029/huss_Amon_E3SM-1-1_piControl_r1i1p1f1_gr_195001-197412.nc'
'http://aims3.llnl.gov/thredds/fileServer/user_pub_work/CMIP6/CMIP/E3SM-Project/E3SM-1-1/piControl/r1i1p1f1/Amon/huss/gr/v20191029/huss_Amon_E3SM-1-1_piControl_r1i1p1f1_gr_197501-199912.nc'
'http://aims3.llnl.gov/thredds/fileServer/user_pub_work/CMIP6/CMIP/E3SM-Project/E3SM-1-1/piControl/r1i1p1f1/Amon/huss/gr/v20191029/huss_Amon_E3SM-1-1_piControl_r1i1p1f1_gr_200001-201412.nc'
)

for i in "${download_files[@]}"
do
   wget $i
done
```