### PR TITLE
Use Solr shards from XML file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ ALLOWED_HOSTS = ['localhost']
 # Address of ESGF Solr
 ESGF_SOLR_URL = 'localhost/solr'
 
-# Solr file shards
+# Path to XML file containing Solr shards
 ESGF_SOLR_SHARDS_XML = '/esg/config/esgf_shards_static.xml'
 
 # Default limit on the number of files allowed in a wget script

--- a/README.md
+++ b/README.md
@@ -22,12 +22,7 @@ ALLOWED_HOSTS = ['localhost']
 ESGF_SOLR_URL = 'localhost/solr'
 
 # Solr file shards
-ESGF_SOLR_SHARDS = [
-                    'localhost:8983/solr',
-                    'localhost:8985/solr',
-                    'localhost:8987/solr',
-                    'localhost:8988/solr'
-                   ]
+ESGF_SOLR_SHARDS_XML = '/esg/config/esgf_shards_static.xml'
 
 # Default limit on the number of files allowed in a wget script
 WGET_SCRIPT_FILE_DEFAULT_LIMIT = 1000
@@ -59,7 +54,7 @@ The parameter `distrib` is used to enable/disable distributed search, where all 
 localhost:8000/wget?distrib=false&dataset_id=...
 ```
 
-The parameter `shards` is used to pass specific Solr shards for use by the dataset search.  Shards are provided as a string of URLs delimited by commas.  If no shards are provided, then the API will use the shards stored in `ESGF_SOLR_SHARDS` in local_settings.py.
+The parameter `shards` is used to pass specific Solr shards for use by the dataset search.  Shards are provided as a string of URLs delimited by commas.  If no shards are provided, then the API will use the shards stored in the file `ESGF_SOLR_SHARDS_XML` in local_settings.py.
 ```
 localhost:8000/wget?shards=localhost:8993/solr,localhost:8994/solr,localhost:8995/solr&dataset_id=...
 ```

--- a/esgf_wget/local_settings_example.py
+++ b/esgf_wget/local_settings_example.py
@@ -11,8 +11,8 @@ ALLOWED_HOSTS = []
 # Address of ESGF Solr
 ESGF_SOLR_URL = ''
 
-# Solr file shards
-ESGF_SOLR_SHARDS = []
+# Path to XML file containing Solr shards
+ESGF_SOLR_SHARDS_XML = ''
 
 # Default limit on the number of files allowed in a wget script
 WGET_SCRIPT_FILE_DEFAULT_LIMIT = 1000

--- a/esgf_wget/views.py
+++ b/esgf_wget/views.py
@@ -4,15 +4,26 @@ from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
+import xml.etree.ElementTree as ET
 import urllib.request
 import urllib.parse
 import datetime
 import json
+import os
 
-from .local_settings import ESGF_SOLR_SHARDS, \
+from .local_settings import ESGF_SOLR_SHARDS_XML, \
                             ESGF_SOLR_URL, \
                             WGET_SCRIPT_FILE_DEFAULT_LIMIT, \
                             WGET_SCRIPT_FILE_MAX_LIMIT
+
+def get_solr_shards_from_xml():
+    shard_list = []
+    if os.path.isfile(ESGF_SOLR_SHARDS_XML):
+        tree = ET.parse(ESGF_SOLR_SHARDS_XML)
+        root = tree.getroot()
+        for value in root:
+            shard_list.append(value.text)
+    return shard_list
 
 def home(request):
     return HttpResponse('esgf-wget')
@@ -25,6 +36,7 @@ def generate_wget_script(request):
     file_limit = WGET_SCRIPT_FILE_DEFAULT_LIMIT
     use_distrib = True
     requested_shards = []
+    xml_shards = get_solr_shards_from_xml()
 
     # Gather dataset_ids and other parameters
     if request.method == 'POST':
@@ -71,8 +83,8 @@ def generate_wget_script(request):
         if len(requested_shards) > 0:
             shards = ','.join([s + '/files' for s in requested_shards])
             query_params.update(dict(shards=shards))
-        elif len(ESGF_SOLR_SHARDS) > 0:
-            shards = ','.join([s + '/files' for s in ESGF_SOLR_SHARDS])
+        elif len(xml_shards) > 0:
+            shards = ','.join([s + '/files' for s in xml_shards])
             query_params.update(dict(shards=shards))
 
     # Fetch the number of files for the query


### PR DESCRIPTION
@muryanto1
This will replace the list of Solr shards from the local settings file with a path to a XML file containing the Solr shards.

This XML file will follow the same format as [esgf_shards_static.xml](https://github.com/ESGF/config/blob/0d3207355fd67ec8defe7ffb3fe325251ddaca93/esgf-prod/esgf_shards_static.xml).