### PR TITLE
Replace local_settings.py with a config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # VSCode
 .vscode/
+
+# Config files
+*.cfg

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ This is ideally done through a virtual environment with virtualenv, or a conda e
 
 Copy the contents of esgf-wget-config.cfg-template to a file named esgf-wget-config.cfg.  Copy the path of this config file to an environment variable `ESGF_WGET_CONFIG`.
 ```
-cd esgf-wget
 cp esgf-wget-config.cfg-template esgf-wget-config.cfg
 export ESGF_WGET_CONFIG=$(pwd)/esgf-wget-config.cfg
 ```
@@ -18,6 +17,12 @@ export ESGF_WGET_CONFIG=$(pwd)/esgf-wget-config.cfg
 Fill out the variables in esgf-wget-config.cfg.  Example below.
 ```
 [django]
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = ...
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
 ALLOWED_HOSTS = localhost,127.0.0.1
 
 # Expand the number of fields allowed for wget API

--- a/README.md
+++ b/README.md
@@ -8,21 +8,27 @@ pip install -r requirements.txt
 ```
 This is ideally done through a virtual environment with virtualenv, or a conda environment using Anaconda Python.
 
-Copy the contents of local_settings_example.py to a file named local_settings.py inside the esgf-wget directory.
+Copy the contents of esgf-wget-config.cfg-template to a file named esgf-wget-config.cfg.  Copy the path of this config file to an environment variable `ESGF_WGET_CONFIG`.
 ```
 cd esgf-wget
-cp local_settings_example.py local_settings.py
+cp esgf-wget-config.cfg-template esgf-wget-config.cfg
+export ESGF_WGET_CONFIG=$(pwd)/esgf-wget-config.cfg
 ```
 
-Fill out the variables in local_settings.py.  Example below.
+Fill out the variables in esgf-wget-config.cfg.  Example below.
 ```
-ALLOWED_HOSTS = ['localhost']
+[django]
+ALLOWED_HOSTS = localhost,127.0.0.1
 
+# Expand the number of fields allowed for wget API
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 1024
+
+[wget]
 # Address of ESGF Solr
-ESGF_SOLR_URL = 'localhost/solr'
+ESGF_SOLR_URL = localhost/solr
 
 # Path to XML file containing Solr shards
-ESGF_SOLR_SHARDS_XML = '/esg/config/esgf_shards_static.xml'
+ESGF_SOLR_SHARDS_XML = /esg/config/esgf_shards_static.xml
 
 # Default limit on the number of files allowed in a wget script
 WGET_SCRIPT_FILE_DEFAULT_LIMIT = 1000

--- a/esgf-wget-config.cfg-template
+++ b/esgf-wget-config.cfg-template
@@ -1,18 +1,21 @@
-
-
+[django]
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = ''
+SECRET_KEY = 
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = 
 
+# Expand the number of fields allowed for wget API
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 1024
+
+[wget]
 # Address of ESGF Solr
-ESGF_SOLR_URL = ''
+ESGF_SOLR_URL = 
 
 # Path to XML file containing Solr shards
-ESGF_SOLR_SHARDS_XML = ''
+ESGF_SOLR_SHARDS_XML = 
 
 # Default limit on the number of files allowed in a wget script
 WGET_SCRIPT_FILE_DEFAULT_LIMIT = 1000

--- a/esgf_wget/settings.py
+++ b/esgf_wget/settings.py
@@ -11,12 +11,32 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
 import os
+import configparser
+
+config = configparser.RawConfigParser()
+
+config_file = os.getenv('ESGF_WGET_CONFIG', default=None)
+
+if config_file is None or not os.path.isfile(config_file):
+    raise Exception('ESGF_WGET_CONFIG is not set, or is not a file.')
 
 try:
-    from .local_settings import *
-except ImportError:
-    print('Unable to load local_settings.py')
-    pass
+    config.read(config_file)
+except IOError:
+    raise Exception('Unable to load config file.')
+
+SECRET_KEY = config['django'].get('SECRET_KEY', '')
+DEBUG = config['django'].getboolean('DEBUG', True)
+ALLOWED_HOSTS = config['django'].get('ALLOWED_HOSTS', '').split(',')
+DATA_UPLOAD_MAX_NUMBER_FIELDS = config['django'].getint(
+    'DATA_UPLOAD_MAX_NUMBER_FIELDS', 10240)
+
+ESGF_SOLR_URL = config['wget'].get('ESGF_SOLR_URL', '')
+ESGF_SOLR_SHARDS_XML = config['wget'].get('ESGF_SOLR_SHARDS_XML', '')
+WGET_SCRIPT_FILE_DEFAULT_LIMIT = config['wget'].getint(
+    'WGET_SCRIPT_FILE_DEFAULT_LIMIT', 1000)
+WGET_SCRIPT_FILE_MAX_LIMIT = config['wget'].getint(
+    'WGET_SCRIPT_FILE_MAX_LIMIT', 100000)
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/esgf_wget/views.py
+++ b/esgf_wget/views.py
@@ -3,6 +3,7 @@ from django.http import HttpResponse
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
+from django.conf import settings
 
 import xml.etree.ElementTree as ET
 import urllib.request
@@ -11,15 +12,10 @@ import datetime
 import json
 import os
 
-from .local_settings import ESGF_SOLR_SHARDS_XML, \
-                            ESGF_SOLR_URL, \
-                            WGET_SCRIPT_FILE_DEFAULT_LIMIT, \
-                            WGET_SCRIPT_FILE_MAX_LIMIT
-
 def get_solr_shards_from_xml():
     shard_list = []
-    if os.path.isfile(ESGF_SOLR_SHARDS_XML):
-        tree = ET.parse(ESGF_SOLR_SHARDS_XML)
+    if os.path.isfile(settings.ESGF_SOLR_SHARDS_XML):
+        tree = ET.parse(settings.ESGF_SOLR_SHARDS_XML)
         root = tree.getroot()
         for value in root:
             shard_list.append(value.text)
@@ -32,8 +28,8 @@ def home(request):
 @csrf_exempt
 def generate_wget_script(request):
 
-    query_url = ESGF_SOLR_URL + '/files/select'
-    file_limit = WGET_SCRIPT_FILE_DEFAULT_LIMIT
+    query_url = settings.ESGF_SOLR_URL + '/files/select'
+    file_limit = settings.WGET_SCRIPT_FILE_DEFAULT_LIMIT
     use_distrib = True
     requested_shards = []
     script_template_file = 'wget-template.sh'
@@ -66,7 +62,7 @@ def generate_wget_script(request):
     if url_params.get('shards'):
         requested_shards = url_params['shards'].split(',')
     if url_params.get('limit'):
-        file_limit = min(int(url_params['limit']), WGET_SCRIPT_FILE_MAX_LIMIT)
+        file_limit = min(int(url_params['limit']), settings.WGET_SCRIPT_FILE_MAX_LIMIT)
     if url_params.get('dataset_id'):
         dataset_id_list = url_params.getlist('dataset_id')
     else:


### PR DESCRIPTION
This change will replace the current way of configuring the wget API. Instead of setting up variables in a file called local_settings.py in the project directory, esgf-wget will use a configuration file stored at the path set in the environment variable `ESGF_WGET_CONFIG`.
```
export ESGF_WGET_CONFIG=/path/to/config.cfg
```