### PR TITLE
Project whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ ESGF_SOLR_URL = localhost/solr
 # Path to XML file containing Solr shards
 ESGF_SOLR_SHARDS_XML = /esg/config/esgf_shards_static.xml
 
+# Path to JSON file containing allowed projects to access for datasets
+ESGF_ALLOWED_PROJECTS_JSON = /esg/config/esgf_allowed_projects.json
+
 # Default limit on the number of files allowed in a wget script
 WGET_SCRIPT_FILE_DEFAULT_LIMIT = 1000
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ WGET_SCRIPT_FILE_MAX_LIMIT = 100000
 # Maximum length for facet values used in the wget directory structure
 WGET_MAX_DIR_LENGTH = 50
 ```
-### Solr shards XML file
-This file contains a list of Solr shards used by the ESGF Solr database for distributed search.  Example below.
+### ESGF_SOLR_SHARDS_XML
+A path to a XML file that contains a list of Solr shards used by the ESGF Solr database for distributed search.  Example below.
 ```
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <shards>
@@ -60,8 +60,8 @@ This file contains a list of Solr shards used by the ESGF Solr database for dist
 </shards>
 ```
 
-### Allowed projects JSON file
-This file contains a list of ESGF projects that are allowed to be used by this API.  Any project that is not listed will cause the API to reject the query.  Example below.
+### ESGF_ALLOWED_PROJECTS_JSON
+A path to a JSON file that contains a list of ESGF projects that are allowed to be used by this API.  Any project that is not listed will cause the API to reject the query.  Example below.
 ```
 {
     "allowed_projects": [

--- a/README.md
+++ b/README.md
@@ -46,6 +46,32 @@ WGET_SCRIPT_FILE_MAX_LIMIT = 100000
 # Maximum length for facet values used in the wget directory structure
 WGET_MAX_DIR_LENGTH = 50
 ```
+### Solr shards XML file
+This file contains a list of Solr shards used by the ESGF Solr database for distributed search.  Example below.
+```
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<shards>
+    <value>localhost:8983/solr</value>
+    <value>localhost:8985/solr</value>
+    <value>localhost:8987/solr</value>
+</shards>
+```
+
+### Allowed projects JSON file
+This file contains a list of ESGF projects that are allowed to be used by this API.  Any project that is not listed will cause the API to reject the query.  Example below.
+```
+{
+    "allowed_projects": [
+        "CMIP6", 
+        "CMIP5", 
+        "CMIP3", 
+        "input4MIPs", 
+        "obs4MIPs", 
+        "CREATE-IP", 
+        "E3SM"
+    ]
+}
+```
 
 Run the API using manage.py.
 ```

--- a/esgf-wget-config.cfg-template
+++ b/esgf-wget-config.cfg-template
@@ -14,6 +14,9 @@ ESGF_SOLR_URL =
 # Path to XML file containing Solr shards
 ESGF_SOLR_SHARDS_XML = 
 
+# Path to JSON file containing allowed projects to access for datasets
+ESGF_ALLOWED_PROJECTS_JSON = 
+
 # Default limit on the number of files allowed in a wget script
 WGET_SCRIPT_FILE_DEFAULT_LIMIT = 1000
 

--- a/esgf_wget/query_utils.py
+++ b/esgf_wget/query_utils.py
@@ -5,6 +5,7 @@ from io import StringIO
 import xml.etree.ElementTree as ET
 import urllib.request
 import urllib.parse
+import json
 import csv
 import os
 
@@ -84,6 +85,10 @@ FIELD_END = "end"
 FIELD_WGET_PATH = "download_structure"
 FIELD_WGET_EMPTYPATH = "download_emptypath"
 
+# fields that specify project
+FIELD_PROJECT = "project"
+FIELD_MIP_ERA = "mip_era"
+
 # fields that are always allowed in queries, in addition to configured facets
 CORE_QUERY_FIELDS = [
         FIELD_ID, FIELD_TYPE, FIELD_REPLICA, FIELD_RETRACTED, FIELD_LATEST,
@@ -96,7 +101,8 @@ CORE_QUERY_FIELDS = [
         FIELD_CHECKSUM, FIELD_CHECKSUM_TYPE, FIELD_DATA_NODE, FIELD_INDEX_NODE,
         FIELD_BBOX, FIELD_LAT, FIELD_LON, FIELD_RADIUS, FIELD_POLYGON,
         FIELD_START, FIELD_END,
-        FIELD_WGET_PATH, FIELD_WGET_EMPTYPATH
+        FIELD_WGET_PATH, FIELD_WGET_EMPTYPATH,
+        FIELD_PROJECT, FIELD_MIP_ERA
         ]
 
 # fields that should NOT be used as facets
@@ -129,6 +135,14 @@ UNSUPPORTED_FIELDS = [
     FIELD_RADIUS,
     FIELD_POLYGON
     ]
+
+# ID fields
+ID_FIELDS = [
+    FIELD_ID,
+    FIELD_DATASET_ID,
+    FIELD_MASTER_ID,
+    FIELD_INSTANCE_ID
+]
 
 
 def split_value(value):
@@ -189,6 +203,20 @@ def get_solr_shards_from_xml():
         for value in root:
             shard_list.append(value.text)
     return shard_list
+
+
+def get_allowed_projects_from_json():
+    """
+    Get allowed ESGF projects from the JSON file specified in the settings
+    as ESGF_ALLOWED_PROJECTS_JSON
+    """
+
+    allowed_projects_list = []
+    if os.path.isfile(settings.ESGF_ALLOWED_PROJECTS_JSON):
+        with open(settings.ESGF_ALLOWED_PROJECTS_JSON, 'r') as js:
+            data = json.load(js)
+            allowed_projects_list = data['allowed_projects']
+    return allowed_projects_list
 
 
 def get_facets_from_solr():

--- a/esgf_wget/settings.py
+++ b/esgf_wget/settings.py
@@ -37,6 +37,8 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = config['django'].getint(
 
 ESGF_SOLR_URL = config['wget'].get('ESGF_SOLR_URL', '')
 ESGF_SOLR_SHARDS_XML = config['wget'].get('ESGF_SOLR_SHARDS_XML', '')
+ESGF_ALLOWED_PROJECTS_JSON = config['wget'].get(
+    'ESGF_ALLOWED_PROJECTS_JSON', '')
 WGET_SCRIPT_FILE_DEFAULT_LIMIT = config['wget'].getint(
     'WGET_SCRIPT_FILE_DEFAULT_LIMIT', 1000)
 WGET_SCRIPT_FILE_MAX_LIMIT = config['wget'].getint(


### PR DESCRIPTION
Resolves #25 

This adds a JSON file that has a list of projects that are allowed to be used by the API.  If a query specifies a project or id (`id`, `master_id`, `dataset_id`, `instance_id`) from a project that is not in the list, then the API will throw an error instead of generating a wget script.

Example error:
```
This query cannot be completed since the project, CORDEX, is not allowed to be accessed by this site. Please redo your
query with unrestricted data only, and request CORDEX data from another site.
```